### PR TITLE
[Fix] Change registration form input field name to expected name 'qua…

### DIFF
--- a/parabellum_web/pages/register.rs
+++ b/parabellum_web/pages/register.rs
@@ -76,7 +76,7 @@ pub fn RegisterPage(
                     }
                     select {
                         class: "input-field",
-                        name: selected_quadrant.clone(),
+                        name: "quadrant",
                         option { value: "NorthEast", selected: selected_quadrant == "NorthEast", "{t!(\"game.starting_position.north_east\", key=\"(+/+)\")}" }
                         option { value: "NorthWest", selected: selected_quadrant == "NorthWest", "{t!(\"game.starting_position.north_west\", key=\"(-/+)\")}" }
                         option { value: "SouthEast", selected: selected_quadrant == "SouthEast", "{t!(\"game.starting_position.south_east\", key=\"(+/-)\")}" }


### PR DESCRIPTION
…drant'.

### Summary:

Submitting the user registration form was causing this error:
"Failed to deserialize form body: missing field quadrant"
This happened because the submitted field name did not match the expected quadrant field.

### Changes:

Updated the form to submit the field with the fixed name quadrant instead of using the variable selected_quadrant.